### PR TITLE
Make cookies persistent for locale, natricon

### DIFF
--- a/src/lib/NatriconContext.js
+++ b/src/lib/NatriconContext.js
@@ -30,7 +30,7 @@ class NatriconProvider extends React.Component {
 
   async setNatricon(toOn) {
     this.setState({ enabled: toOn }, () => {
-      Cookies.set("nanocrawler.natriconOn", toOn ? "true" : "false");
+      Cookies.set("nanocrawler.natriconOn", toOn ? "true" : "false", { expires: 365 });
     });
   }
 

--- a/src/lib/TranslationContext.js
+++ b/src/lib/TranslationContext.js
@@ -52,7 +52,7 @@ class TranslationProvider extends React.Component {
     moment.locale(langConfig.momentLocale);
 
     this.setState({ language, messages }, () => {
-      Cookies.set("nanocrawler.locale", language);
+      Cookies.set("nanocrawler.locale", language, { expires: 365 });
     });
   }
 


### PR DESCRIPTION
Cookies are used to store user preferences (currently only locale and natricon on/off). They're currently session cookies which only live as long as the browser determines the session should last (typically erased when browser is closed/reopened).

Since these are user preferences, make them persistent with an expiration of 365 days.