### PR TITLE
Support new monKey

### DIFF
--- a/src/app/partials/MonKey.js
+++ b/src/app/partials/MonKey.js
@@ -26,7 +26,7 @@ export default class MonKey extends React.PureComponent {
 
   get imageUrl() {
     const { account } = this.props;
-    return `https://monkeys.appditto.com/?address=${account}`;
+    return `https://monkey.banano.cc/api/v1/monkey/${account}?svc=creeper`;
   }
 
   loadingState() {


### PR DESCRIPTION
There's a new monKey API and the old one is deprecated. Update creeper to use monkey.banano.cc instead.