### PR TITLE
Set include_only_confirmed to true

### DIFF
--- a/src/server/responders/v2/accounts.js
+++ b/src/server/responders/v2/accounts.js
@@ -176,7 +176,8 @@ export default function(app, nano) {
             accounts: [req.params.account],
             source: true,
             threshold: Currency.toRaw(0.000001),
-            sorting: true
+            sorting: true,
+            include_only_confirmed: true
           });
 
           if (resp.error) throw new BadRequest(resp.error);


### PR DESCRIPTION
This PR excludes transactions that haven't yet been confirmed by the network from the list of transactions that are ready to be received by recipient.

This is one of two potential solutions. An alternative solution would require grouping pending transactions into two lists: "Transactions pending network confirmation" if "confirmed" is set to 'false', and "Transactions ready to be received" if "confirmed" is set to 'true'.

\-

https://docs.nano.org/commands/rpc-protocol/?h=rpc#accounts_pending

**Optional "include_only_confirmed"**

*version 19.0+*
Boolean, false by default. Only returns blocks which have their confirmation height set or are undergoing confirmation height processing.