### PR TITLE
Allow running without redis

### DIFF
--- a/src/server/accounts.js
+++ b/src/server/accounts.js
@@ -6,6 +6,9 @@ import clientConfig from "../client-config.json";
 import Currency from "../lib/Currency";
 
 const redisClient = redis.createClient(config.redis);
+redisClient.on("error", err => {
+  console.error("Redis unavailable");
+});
 const nano = new Nano({ url: config.nodeHost });
 
 async function calculateAccountList() {

--- a/src/server/accounts.js
+++ b/src/server/accounts.js
@@ -6,9 +6,6 @@ import clientConfig from "../client-config.json";
 import Currency from "../lib/Currency";
 
 const redisClient = redis.createClient(config.redis);
-redisClient.on("error", err => {
-  console.error("Redis unavailable");
-});
 const nano = new Nano({ url: config.nodeHost });
 
 async function calculateAccountList() {

--- a/src/server/helpers/frontiers.js
+++ b/src/server/helpers/frontiers.js
@@ -4,9 +4,6 @@ import redis from "redis";
 import config from "../../../server-config.json";
 
 const redisClient = redis.createClient(config.redis);
-redisClient.on("error", err => {
-  console.error("Redis unavailable");
-});
 const zcount = promisify(redisClient.zcount.bind(redisClient));
 const zrevrange = promisify(redisClient.zrevrange.bind(redisClient));
 

--- a/src/server/helpers/frontiers.js
+++ b/src/server/helpers/frontiers.js
@@ -4,6 +4,9 @@ import redis from "redis";
 import config from "../../../server-config.json";
 
 const redisClient = redis.createClient(config.redis);
+redisClient.on("error", err => {
+  console.error("Redis unavailable");
+});
 const zcount = promisify(redisClient.zcount.bind(redisClient));
 const zrevrange = promisify(redisClient.zrevrange.bind(redisClient));
 

--- a/src/server/helpers/tpsCalculator.js
+++ b/src/server/helpers/tpsCalculator.js
@@ -3,6 +3,9 @@ import redis from "redis";
 import config from "../../../server-config.json";
 
 const redisClient = redis.createClient(config.redis);
+redisClient.on("error", err => {
+  console.error("Redis unavailable");
+});
 const zRangeByScore = promisify(redisClient.zrangebyscore.bind(redisClient));
 
 const STORAGE_KEY = `nano-control-panel/${config.redisNamespace ||

--- a/src/server/helpers/tpsCalculator.js
+++ b/src/server/helpers/tpsCalculator.js
@@ -3,9 +3,6 @@ import redis from "redis";
 import config from "../../../server-config.json";
 
 const redisClient = redis.createClient(config.redis);
-redisClient.on("error", err => {
-  console.error("Redis unavailable");
-});
 const zRangeByScore = promisify(redisClient.zrangebyscore.bind(redisClient));
 
 const STORAGE_KEY = `nano-control-panel/${config.redisNamespace ||

--- a/src/server/networkTps.js
+++ b/src/server/networkTps.js
@@ -4,6 +4,9 @@ import redis from "redis";
 import config from "../../server-config.json";
 
 const redisClient = redis.createClient(config.redis);
+redisClient.on("error", err => {
+  console.error("Redis unavailable");
+});
 
 const nano = new Nano({ url: config.nodeHost });
 const STORAGE_PERIOD = 60 * 60 * 24 * 7 * 1000; // 1 week

--- a/src/server/networkTps.js
+++ b/src/server/networkTps.js
@@ -4,9 +4,6 @@ import redis from "redis";
 import config from "../../server-config.json";
 
 const redisClient = redis.createClient(config.redis);
-redisClient.on("error", err => {
-  console.error("Redis unavailable");
-});
 
 const nano = new Nano({ url: config.nodeHost });
 const STORAGE_PERIOD = 60 * 60 * 24 * 7 * 1000; // 1 week


### PR DESCRIPTION
Addresses issue https://github.com/meltingice/nanocrawler/issues/37 where README states redis config is optional, but in practice this results in the server crashing.

This is not the most graceful solution since it just removes functionality rather than providing a Redis alternative, but it does allow the server to stay up and performs some functions.


Alternative may be to make Redis a hard requirement and update the README accordingly